### PR TITLE
auto activate Glass mode on start if glassAuto is not set to False

### DIFF
--- a/GlassGui.py
+++ b/GlassGui.py
@@ -20,6 +20,7 @@
 
 
 import FreeCADGui as Gui
+import FreeCAD
 from PySide import QtGui
 from PySide import QtCore
 
@@ -174,6 +175,8 @@ def onStart():
         timer.timeout.disconnect(onStart)
         findDock()
         createActions()
+        if FreeCAD.ParamGet("User parameter:BaseApp/Glass").GetBool("glassAuto",1):
+            setMode() # activate Glass mode
         timer.timeout.connect(onResize)
         timer.start(2000)
 


### PR DESCRIPTION
Simple addition that automatically activates Glass mode and can be turned off by creating the boolean parameter BaseApp/Glass/glassAuto and setting it to False