### PR TITLE
fixed text problem when renaming node.

### DIFF
--- a/GlassGui.py
+++ b/GlassGui.py
@@ -93,8 +93,9 @@ def applyGlass(boolean, widget):
         widget.setAttribute(QtCore.Qt.WA_TranslucentBackground, boolean)
     except:
         pass
+    transparent_classes = [QtGui.QScrollBar, QtGui.QLineEdit, QtGui.QAbstractButton, QtGui.QHeaderView, QtGui.QDockWidget]
     try:
-        if boolean:
+        if boolean and (widget.__class__ in transparent_classes) or (widget.objectName() in ['qt_scrollarea_hcontainer', 'qt_scrollarea_vcontainer']):
             widget.setStyleSheet("background:transparent; border:none; color:white;")
         else:
             widget.setStyleSheet("")
@@ -151,8 +152,10 @@ def widgetList(boolean):
                         child = True
 
     for child in children:
-        applyGlass(boolean, child)
-
+        if isinstance(child, QtGui.QWidget):
+            applyGlass(boolean, child)
+    if boolean:
+        dock.setStyleSheet("")
 
 def setMode():
     """Set dock or overlay widget mode."""


### PR DESCRIPTION
I found a problem when trying to rename nodes in the tree as the text editor is transparent the edited text interferes with the node's original name below it and it becomes hard to see what you are writing.

This pull request should fix the problem, tested on windows and linux using FreeCad 0.19.23578 which is the latest at the time of writing this.